### PR TITLE
Revert "Disallow recursive bindings outside of application heads"

### DIFF
--- a/lib/smyth/term_gen.ml
+++ b/lib/smyth/term_gen.ml
@@ -428,9 +428,6 @@ and rel_gen_e
           let* (specialized_type, specialized_exp) =
             instantiations sigma gamma rel_name rel_type
           in
-          let* _ =
-            Nondet.guard (match rel_bind_spec with Rec _ -> false | _ -> true)
-          in
           if
             Type.matches goal_type specialized_type
               && Type.matches_dec goal_dec rel_bind_spec


### PR DESCRIPTION
Turns out I made the termination checker a little too strong 😅.
This PR reverts the problematic commit so that all the recursive examples are working again (fixing #17).
This leaves the issue that the termination checker is not strong enough because it allows the use of recursive functions without any arguments, but so far this only seems to give warnings, not bugs.