### PR TITLE
Smyth bugfixes 2

### DIFF
--- a/lib/smyth/params.ml
+++ b/lib/smyth/params.ml
@@ -21,7 +21,7 @@ let ranking_method : ranking_method ref =
 (** The method to rank synthesis solutions. *)
 
 let max_solution_count : int option ref =
-  ref (Some 30)
+  ref (Some 40)
 (** The maximum synthesis solution count. [None] indicates no bound/infinity. *)
 
 let uneval_case_budget : int ref =

--- a/lib/smyth/term_gen.ml
+++ b/lib/smyth/term_gen.ml
@@ -537,7 +537,7 @@ and gen_i
                       ; rel_binding = None
                       ; goal =
                           ( Type_ctx.concat_type
-                              [ (arg_name, (tau1, Dec f_name))
+                              [ (arg_name, (tau1, Arg f_name))
                               ; (f_name, (goal_type, Rec f_name))
                               ]
                               Type_ctx.empty
@@ -649,7 +649,7 @@ and rel_gen_i
                 ; rel_binding = Some rel_binding
                 ; goal =
                     ( Type_ctx.concat_type
-                        [ (arg_name, (tau1, Dec f_name))
+                        [ (arg_name, (tau1, Arg f_name))
                         ; (f_name, (goal_type, Rec f_name))
                         ]
                         gamma


### PR DESCRIPTION
This pull request fixes the incorrect use of `Dec` instead of `Arg` when introducing fixpoints during term generation. As stated in section 5.2.1 of Osera's thesis, a binding specification of the form `Dec f` can only be obtained by pattern matching on a binding with specification `Arg f` or `Dec f`. Although this fix does not seem to lead to synthesis results that were previously not possible, it should, in theory, improve performance by preventing terms like `let f1 = \x1 -> f1 x1 in f1` from being generated.

Furthermore, this pull request increases the `max_solution_count`, to compensate for the previously missing solutions introduced by #16. In experiment 3a and 6a, the recursive solution to `tree_count_leaves.elm` was not reached due to new possible (overspecialized) solutions pushing the recursive solution beyond the max solution count. It is not entirely clear what the exact value should be (a `max_solution_count` of 34 already seems to do the trick), but I decided to err on the safe side.